### PR TITLE
Use file.path for md5 hash fixes #19

### DIFF
--- a/index.js
+++ b/index.js
@@ -239,7 +239,7 @@ function TinyPNG(opt, obj) {
             sigs: {},
 
             calc: function(file, cb) {
-                var md5 = crypto.createHash('md5').update(file.contents).digest('hex');
+                var md5 = crypto.createHash('md5').update(file.path).digest('hex');
 
                 cb && cb(md5);
 

--- a/test/init.js
+++ b/test/init.js
@@ -144,7 +144,7 @@ describe('tinypng', function() {
 				var file = new TestFile();
 
 				hash.calc(file, function(md5) {
-					expect(md5).to.equal(crypto.createHash('md5').update(file.contents).digest('hex'));
+					expect(md5).to.equal(crypto.createHash('md5').update(file.path).digest('hex'));
 
 					done();
 				});


### PR DESCRIPTION
Using the file path as md5 hash should be safer than the file contens from buffer and fixes the problem with md5 hashes and the option use same destination.